### PR TITLE
Adding mkdir for $(libdir) in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,4 +29,5 @@ install-exec-hook:
 	[ "$(PERL5LIB)" == "" ] || cd "$(DESTDIR)$(exec_prefix)" && $(PERL) -i -p -e 's{.*# PERL5LIB}{use lib qw($(PERL5LIB)); # PERL5LIB}' $(BIN) || true
 	cd "$(DESTDIR)$(exec_prefix)" && $(PERL) -i -p -e 's{.*# LIBDIR}{use lib qw($(libdir)); # LIBDIR}' $(BIN)
 	cd "$(DESTDIR)$(exec_prefix)" && $(PERL) -i -p -e 's{^#!.*perl.*}{#!$(PERL)};' $(BIN)
+	mkdir -p $(DESTDIR)$(libdir)
 	[ ! -d $(THIRDPARTY_DIR)/lib/perl5 ] || cp -fr $(THIRDPARTY_DIR)/lib/perl5/* $(DESTDIR)$(libdir)


### PR DESCRIPTION
On my OS ( OS X 10.10.5 ) the cp -rf fails with an unrelated error if the $(libdir) does not exist.  There is probably a more elegant way to handle this but the mkdir -p certainly takes care of it.
