### PR TITLE
if chain options are omitted write cert and chain to the file specifi…

### DIFF
--- a/bin/acmefetch
+++ b/bin/acmefetch
@@ -338,6 +338,9 @@ sub getCertificates {
                 $fh = IO::File->new( $chainFile, "w" )
                     || die "Write $chainFile: $!";
             }
+            else {
+                $cert->{chainFormat} = $cert->{certFormat};
+            }
             my $chainData = convertCert($acme->chain(),'DER',$cert->{chainFormat});
             print $fh $chainData; 
             $fh->close();

--- a/bin/acmefetch
+++ b/bin/acmefetch
@@ -323,33 +323,24 @@ sub getCertificates {
         }
         my $csrFile = makeCsr($cfg,$cert);
         eval {
+            my $certData = convertCert($acme->sign( $csrFile ),'DER',$cert->{certFormat});
+            my $certFile = $cert->{certOutput};
+            saveAway($certFile);
+            my $fh = IO::File->new( $certFile, "w" )
+                || die "Write $certFile: $!";
+            print $fh $certData;
+            
+            # chain file wanted -> write separate chain file, otherwise append to cert file
             if ($cert->{chainOutput}){
-                my $certData = convertCert($acme->sign( $csrFile ),'DER',$cert->{certFormat});
-                my $certFile = $cert->{certOutput};
-                saveAway($certFile);
-                my $fh = IO::File->new( $certFile, "w" )
-                    || die "Write $certFile: $!";
-                print $fh $certData;
+                my $chainFile = $cert->{chainOutput};
                 $fh->close();
-                my $chainData = convertCert($acme->chain(),'DER',$cert->{chainFormat});
-                saveAway($cert->{chainOutput});
-                my $fh2 = IO::File->new( $cert->{chainOutput}, "w" )
-                    || die "Write $cert->{chainOutput}: $!";
-                print $fh2 $chainData;
-                $fh2->close();
+                saveAway($chainFile);
+                $fh = IO::File->new( $chainFile, "w" )
+                    || die "Write $chainFile: $!";
             }
-            # no chain file wanted -> include chain in cert file
-            else {
-                my $certData = convertCert($acme->sign( $csrFile ),'DER',$cert->{certFormat});
-                my $certFile = $cert->{certOutput};
-                my $chainData = convertCert($acme->chain(),'DER',$cert->{chainFormat});
-                saveAway($certFile);
-                my $fh = IO::File->new( $certFile, "w" )
-                    || die "Write $certFile: $!";
-                print $fh $certData;
-                print $fh $chainData;
-                $fh->close();
-            }
+            my $chainData = convertCert($acme->chain(),'DER',$cert->{chainFormat});
+            print $fh $chainData; 
+            $fh->close();
             saveAway($cert->{keyOutput});
             rename $cert->{keyOutput}.'.'.$$, $cert->{keyOutput};
         };

--- a/bin/acmefetch
+++ b/bin/acmefetch
@@ -117,11 +117,13 @@ sub getDataProcessor {
                 chainOutput => {
                     description => 'chain output file',
                     validator => $vf->file('>>','chain file'),
+                    optional => 1,
                 },
                 chainFormat => {
                     description => 'PEM or DER output format for the chain file',
                     validator => $vf->rx('^(DER|PEM)','Pick DER or PEM'),
                     default => 'PEM',
+                    optional => 1,
                 },
                 commonName => {
                     description => 'designate the common name in the certificate. the other sites will be listed as subjectAltName entries.',
@@ -321,19 +323,33 @@ sub getCertificates {
         }
         my $csrFile = makeCsr($cfg,$cert);
         eval {
-            my $certData = convertCert($acme->sign( $csrFile ),'DER',$cert->{certFormat});
-            my $certFile = $cert->{certOutput};
-            saveAway($certFile);
-            my $fh = IO::File->new( $certFile, "w" )
-                || die "Write $certFile: $!";
-            print $fh $certData;
-            $fh->close();
-            my $chainData = convertCert($acme->chain(),'DER',$cert->{chainFormat});
-            saveAway($cert->{chainOutput});
-            my $fh2 = IO::File->new( $cert->{chainOutput}, "w" )
-                || die "Write $cert->{chainOutput}: $!";
-            print $fh2 $chainData;
-            $fh2->close();
+            if ($cert->{chainOutput}){
+                my $certData = convertCert($acme->sign( $csrFile ),'DER',$cert->{certFormat});
+                my $certFile = $cert->{certOutput};
+                saveAway($certFile);
+                my $fh = IO::File->new( $certFile, "w" )
+                    || die "Write $certFile: $!";
+                print $fh $certData;
+                $fh->close();
+                my $chainData = convertCert($acme->chain(),'DER',$cert->{chainFormat});
+                saveAway($cert->{chainOutput});
+                my $fh2 = IO::File->new( $cert->{chainOutput}, "w" )
+                    || die "Write $cert->{chainOutput}: $!";
+                print $fh2 $chainData;
+                $fh2->close();
+            }
+            # no chain file wanted -> include chain in cert file
+            else {
+                my $certData = convertCert($acme->sign( $csrFile ),'DER',$cert->{certFormat});
+                my $certFile = $cert->{certOutput};
+                my $chainData = convertCert($acme->chain(),'DER',$cert->{chainFormat});
+                saveAway($certFile);
+                my $fh = IO::File->new( $certFile, "w" )
+                    || die "Write $certFile: $!";
+                print $fh $certData;
+                print $fh $chainData;
+                $fh->close();
+            }
             saveAway($cert->{keyOutput});
             rename $cert->{keyOutput}.'.'.$$, $cert->{keyOutput};
         };
@@ -406,6 +422,10 @@ Use the F<acmefetch.cfg> file to specify what should be done.
 
 If a key or cert file gets replaced, the old version is renamed to end
 with a timestamp of its last modification date.
+
+=head1 CERT NOTES
+
+If you omit the chainOutput and chainFormat keys in your config, key and chain get written to the file you specify in certOutput. Cert first, then chain. E.g. the way nginx expects it.
 
 =head1 APACHE NOTES
 


### PR DESCRIPTION
…ed in certOutput. E.g. for nginx

as discussed last week.

There is one point I am unsure how much checking there should be. Atm nonsensical combinations of chainOutput and chainFormat are possible; no enforcement of either both options present or absent. 