### PR TITLE
chainOutput and chainFormat not supported anymore

### DIFF
--- a/etc/acmefetch.cfg.dist
+++ b/etc/acmefetch.cfg.dist
@@ -10,8 +10,6 @@
             "certFormat": "PEM",
             "keyOutput": "/etc/ssl/private/testCert.key",
             "keyFormat": "PEM",
-            "chainOutput": "/etc/ssl/certs/testCertChain.pem",
-            "chainFormat": "PEM",
             "commonName": "my.web.domain",
             "SITES": {
                 "my.web.domain": {


### PR DESCRIPTION
Due to a change in the API the chain-certificates are now added to the server cert.

https://github.com/oetiker/AcmeFetch/issues/30