### PR TITLE
restore missing '# CONFFILE' tag

### DIFF
--- a/bin/acmefetch
+++ b/bin/acmefetch
@@ -36,7 +36,7 @@ sub main()
     if($opt{man})      { pod2usage(-exitstatus => 0, -verbose => 2) }
     if($opt{version})  { print "acmefetch $VERSION\n"; exit(0) }
 
-    my $cfg = loadCfg($opt{cfg} // $FindBin::RealBin.'/../etc/acmefetch.cfg');
+    my $cfg = loadCfg($opt{cfg} // $FindBin::RealBin.'/../etc/acmefetch.cfg'); # CONFFILE
 
 
     getCertificates($cfg);


### PR DESCRIPTION
without the tag, `make install` won't honour `sysconfdir` as the substitution regexp does not match